### PR TITLE
Add support for JSON file path for Weather API key in documentation

### DIFF
--- a/docs/configuration/panel.md
+++ b/docs/configuration/panel.md
@@ -469,6 +469,12 @@ The Clock Menu displays the time, calendar, and the weather. In the **Clock Menu
   - The weather location
   - The weather unit
   - The weather API key
+    - Instead of plain text, you can also specify a file path to a JSON file that contains the API key in the following format:
+      ```json
+      {
+        "weather_api_key": "your_api_key_goes_here"
+      }
+      ```
   - The weather refresh rate
 
 The Weather API key is required to fetch weather data. You can get a free API key from [WeatherAPI's Website](https://weatherapi.com/)


### PR DESCRIPTION
Thought about adding this to the documentation, as I had to dig through the source code to find out I could simply put a path into the weather key variable. I have also found multiple commit on GitHub containing the plain API-Key, so maybe this will prevent most future commits of plain keys and result in more paths xD

Will look like this:
![image](https://github.com/user-attachments/assets/5cba33c7-c5f9-4a4d-934b-d9732598b41a)

