### PR TITLE
fix: nixos bar layout example

### DIFF
--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -167,23 +167,24 @@ options that are available.
 { inputs, ... }:
 {
   programs.hyprpanel = {
-    # Configure bar layouts for monitors.
-    # See 'https://hyprpanel.com/configuration/panel.html'.
-    # Default: null
-    layout = {
-      "bar.layouts" = {
-        "0" = {
-          left = [ "dashboard" "workspaces" ];
-          middle = [ "media" ];
-          right = [ "volume" "systray" "notifications" ];
-        };
-      };
-    };
-
     # Configure and theme almost all options from the GUI.
     # See 'https://hyprpanel.com/configuration/settings.html'.
     # Default: <same as gui>
     settings = {
+
+      # Configure bar layouts for monitors.
+      # See 'https://hyprpanel.com/configuration/panel.html'.
+      # Default: null
+      layout = {
+        bar.layouts = {
+          "0" = {
+            left = [ "dashboard" "workspaces" ];
+            middle = [ "media" ];
+            right = [ "volume" "systray" "notifications" ];
+          };
+        };
+      };
+
       bar.launcher.autoDetectIcon = true;
       bar.workspaces.show_icons = true;
 


### PR DESCRIPTION
Fixed `programs.hyprpanel.layout` not exists and being moved to `programs.hyprpanel.settings`
See the [home-manager example](https://github.com/nix-community/home-manager/blob/e4bf85da687027cfc4a8853ca11b6b86ce41d732/modules/programs/hyprpanel/default.nix#L26-L41) and yes this is how it currently works see [this](https://github.com/Kathund/nix-config/blob/0a2f171dbe000a83efe2033fb5cf25342b0a4927/programs/hypr/panel/default.nix#L40-L57)